### PR TITLE
Remove public packet fields

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -64,7 +64,7 @@ impl Connection {
                 Ok(a) => a,
             };
 
-            assert_eq!(Block::new(current_block), ack.body.block);
+            assert_eq!(Block::new(current_block), ack.body.block());
             current_block += 1;
 
             if bytes_read < MAX_PAYLOAD_SIZE {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -29,12 +29,12 @@ impl Connection {
                 Ok(d) => d,
             };
 
-            let _ = writer.write(&data.body.data()[..])?;
+            let _ = writer.write(&data.body().data()[..])?;
 
-            let ack = Packet::ack(data.body.block());
+            let ack = Packet::ack(data.body().block());
             let _ = self.socket.send(&ack.into_bytes()[..])?;
 
-            if data.body.data().len() < MAX_PAYLOAD_SIZE {
+            if data.body().data().len() < MAX_PAYLOAD_SIZE {
                 break;
             }
         }
@@ -64,7 +64,7 @@ impl Connection {
                 Ok(a) => a,
             };
 
-            assert_eq!(Block::new(current_block), ack.body.block());
+            assert_eq!(Block::new(current_block), ack.body().block());
             current_block += 1;
 
             if bytes_read < MAX_PAYLOAD_SIZE {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -29,12 +29,12 @@ impl Connection {
                 Ok(d) => d,
             };
 
-            let _ = writer.write(&data.body.data[..])?;
+            let _ = writer.write(&data.body.data()[..])?;
 
-            let ack = Packet::ack(data.body.block);
+            let ack = Packet::ack(data.body.block());
             let _ = self.socket.send(&ack.into_bytes()[..])?;
 
-            if data.body.data.len() < MAX_PAYLOAD_SIZE {
+            if data.body.data().len() < MAX_PAYLOAD_SIZE {
                 break;
             }
         }

--- a/src/packet/ack.rs
+++ b/src/packet/ack.rs
@@ -13,13 +13,18 @@ use crate::packet::sealed::Packet;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ack {
     /// The number of the block that is being acknowledged.
-    pub block: Block,
+    block: Block,
 }
 
 impl Ack {
     /// Creates a new `Ack` packet.
     pub fn new(block: Block) -> Self {
         Self { block }
+    }
+
+    /// Returns the number of the block that is being acknowledged
+    pub fn block(&self) -> Block {
+        self.block
     }
 }
 

--- a/src/packet/data.rs
+++ b/src/packet/data.rs
@@ -15,10 +15,10 @@ use crate::packet::sealed::Packet;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Data {
     /// The identifier for this data.
-    pub block: Block,
+    block: Block,
 
     /// The payload.
-    pub data: Vec<u8>,
+    data: Vec<u8>,
 }
 
 impl Data {
@@ -28,6 +28,16 @@ impl Data {
             block,
             data: data.as_ref().to_vec(),
         }
+    }
+
+    /// Returns the identifier for the data
+    pub fn block(&self) -> Block {
+        self.block
+    }
+
+    /// Returns the payload
+    pub fn data(&self) -> &Vec<u8> {
+        &self.data
     }
 }
 

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -80,9 +80,9 @@ impl fmt::Display for Code {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error {
     /// Describes what type of error this is.
-    pub code: Code,
+    code: Code,
     /// The error's message, if any.
-    pub message: String,
+    message: String,
 }
 
 impl Error {
@@ -92,6 +92,16 @@ impl Error {
             code,
             message: message.as_ref().to_string(),
         }
+    }
+
+    /// Returns the error code
+    pub fn code(&self) -> Code {
+        self.code
+    }
+
+    /// Returns the error message
+    pub fn message(&self) -> &str {
+        self.message.as_str()
     }
 }
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -144,14 +144,14 @@ impl From<io::Error> for Packet<Error> {
 
 impl From<Packet<Error>> for io::Error {
     fn from(err: Packet<Error>) -> io::Error {
-        let kind = match err.body.code {
+        let kind = match err.body.code() {
             Code::FileNotFound => ErrorKind::NotFound,
             Code::AccessViolation => ErrorKind::PermissionDenied,
             Code::FileAlreadyExists => ErrorKind::AlreadyExists,
             _ => ErrorKind::Other,
         };
 
-        io::Error::new(kind, err.body.message)
+        io::Error::new(kind, err.body.message())
     }
 }
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -67,10 +67,10 @@ impl IntoBytes for Block {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Packet<T: sealed::Packet> {
     /// Describes the packet.
-    pub header: Opcode,
+    header: Opcode,
 
     /// Contains the packet payload.
-    pub body: T,
+    body: T,
 }
 
 impl<T: sealed::Packet> Packet<T> {
@@ -79,6 +79,16 @@ impl<T: sealed::Packet> Packet<T> {
             header: T::OPCODE,
             body,
         }
+    }
+
+    /// Returns the opcode for the packet
+    pub fn header(&self) -> Opcode {
+        self.header
+    }
+
+    /// Returns a reference to the packet's payload
+    pub fn body(&self) -> &T {
+        &self.body
     }
 }
 

--- a/src/packet/rq/mod.rs
+++ b/src/packet/rq/mod.rs
@@ -16,8 +16,18 @@ pub use wrq::Wrq;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Rq {
-    pub filename: String,
-    pub mode: Mode,
+    filename: String,
+    mode: Mode,
+}
+
+impl Rq {
+    pub fn filename(&self) -> &str {
+        self.filename.as_str()
+    }
+
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
 }
 
 impl FromBytes for Rq {

--- a/src/packet/rq/rrq.rs
+++ b/src/packet/rq/rrq.rs
@@ -10,13 +10,18 @@ use crate::packet::sealed::Packet;
 
 /// A read request.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Rrq(pub Rq);
+pub struct Rrq(Rq);
 
 impl Rrq {
     /// Creates a new `Rrq`.
     pub fn new<T: AsRef<str>>(filename: T, mode: Mode) -> Self {
         let filename = filename.as_ref().to_string();
         Self(Rq { filename, mode })
+    }
+
+    /// Returns a reference to the inner request
+    pub fn request(&self) -> &Rq {
+        &self.0
     }
 }
 

--- a/src/packet/rq/wrq.rs
+++ b/src/packet/rq/wrq.rs
@@ -10,13 +10,18 @@ use crate::packet::sealed::Packet;
 
 /// A write request.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Wrq(pub Rq);
+pub struct Wrq(Rq);
 
 impl Wrq {
     /// Creates a new `Wrq`.
     pub fn new<T: AsRef<str>>(filename: T, mode: Mode) -> Self {
         let filename = filename.as_ref().to_string();
         Self(Rq { filename, mode })
+    }
+
+    /// Returns a reference to the inner request
+    pub fn request(&self) -> &Rq {
+        &self.0
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -119,7 +119,7 @@ impl Handler {
                 .create(true)
                 /* FIXME: Not sure why this hangs if create is not specified */
                 .truncate(true)
-                .open(wrq.body.0.filename)
+                .open(&wrq.body.request().filename)
             {
                 Ok(f) => f,
                 Err(e) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -98,7 +98,7 @@ impl Handler {
         if let Direction::Get(rrq) = self.direction {
             let f = match OpenOptions::new()
                 .read(true)
-                .open(&rrq.body().request().filename)
+                .open(rrq.body().request().filename())
             {
                 Ok(f) => f,
                 Err(e) => {
@@ -122,7 +122,7 @@ impl Handler {
                 .create(true)
                 /* FIXME: Not sure why this hangs if create is not specified */
                 .truncate(true)
-                .open(&wrq.body().request().filename)
+                .open(wrq.body().request().filename())
             {
                 Ok(f) => f,
                 Err(e) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -96,7 +96,7 @@ impl Handler {
 
     fn get(self) -> Result<()> {
         if let Direction::Get(rrq) = self.direction {
-            let f = match OpenOptions::new().read(true).open(rrq.body.0.filename) {
+            let f = match OpenOptions::new().read(true).open(&rrq.body.request().filename) {
                 Ok(f) => f,
                 Err(e) => {
                     let error: Packet<Error> = e.into();

--- a/src/server.rs
+++ b/src/server.rs
@@ -96,7 +96,10 @@ impl Handler {
 
     fn get(self) -> Result<()> {
         if let Direction::Get(rrq) = self.direction {
-            let f = match OpenOptions::new().read(true).open(&rrq.body.request().filename) {
+            let f = match OpenOptions::new()
+                .read(true)
+                .open(&rrq.body.request().filename)
+            {
                 Ok(f) => f,
                 Err(e) => {
                     let error: Packet<Error> = e.into();

--- a/src/server.rs
+++ b/src/server.rs
@@ -98,7 +98,7 @@ impl Handler {
         if let Direction::Get(rrq) = self.direction {
             let f = match OpenOptions::new()
                 .read(true)
-                .open(&rrq.body.request().filename)
+                .open(&rrq.body().request().filename)
             {
                 Ok(f) => f,
                 Err(e) => {
@@ -122,7 +122,7 @@ impl Handler {
                 .create(true)
                 /* FIXME: Not sure why this hangs if create is not specified */
                 .truncate(true)
-                .open(&wrq.body.request().filename)
+                .open(&wrq.body().request().filename)
             {
                 Ok(f) => f,
                 Err(e) => {


### PR DESCRIPTION
Removes public access to struct fields on the following items:
- [x] src/packet/ack.rs
- [x] src/packet/error.rs
- [x] src/packet/mod.rs
- [x] src/packet/data.rs
- [x] src/packet/rq/wrq.rs
- [x] src/packet/rq/mod.rs
- [x] src/packet/rq/rrq.rs