### PR TITLE
Added server returns error for PUT on file that already exists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,15 @@ rand = "0.7.3"
 
 [dev-dependencies]
 tempfile = "3.1.0"
+
+[[example]]
+name = "client"
+path = "examples/client.rs"
+
+[[example]]
+name = "server"
+path = "examples/server.rs"
+
+[[example]]
+name = "server_with_threads"
+path = "examples/server_with_threads.rs"

--- a/examples/server_with_threads.rs
+++ b/examples/server_with_threads.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::thread;
+
+use tftp::Server;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let addr = args.next().unwrap();
+    let wd = args.next().unwrap();
+
+    let server = Server::new(addr.clone(), wd).unwrap();
+    println!("Serving Trivial File Transfer Protocol (TFTP) @ {}", addr);
+
+    while let Ok(h) = server.serve() {
+        print!("Handling request...");
+
+        thread::spawn(|| match h.handle() {
+            Ok(()) => println!("OK"),
+            Err(e) => println!("FAIL: {:?}", e),
+        });
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -70,6 +70,16 @@ impl Builder<ConnectTo> {
             socket: self.data.socket,
         }
     }
+
+    /// Creates an instance with a different socket from the origninal instance.
+    pub fn try_clone(&self) -> Result<Self> {
+        let new_sock_builder = Builder::new()?;
+        let data = ConnectTo {
+            server: self.data.server.clone(),
+            socket: new_sock_builder.data.socket,
+        };
+        Ok(Builder { data })
+    }
 }
 
 impl Client {

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use rand::Rng;
 
 use crate::bytes::{FromBytes, IntoBytes};
 use crate::connection::Connection;
+use crate::connection::MIN_PORT_NUMBER;
 use crate::packet::*;
 
 /// The initial state for building a `Client`.
@@ -41,7 +42,7 @@ impl Builder<New> {
     /// for this connection.
     pub fn new() -> Result<Self> {
         let mut rng = rand::thread_rng();
-        let port: u16 = rng.gen_range(1001, u16::MAX);
+        let port: u16 = rng.gen_range(MIN_PORT_NUMBER, u16::MAX);
         let bind_to = format!("0.0.0.0:{}", port);
         let socket = UdpSocket::bind(bind_to)?;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -26,7 +26,12 @@ impl Connection {
 
             let data: Packet<Data> = self.socket.expect_packet(&buf[..bytes_recvd])?;
 
-            let _ = writer.write(&data.body.data[..])?;
+            if let Err(err) = writer.write_all(&data.body.data[..]) {
+                let _ = self
+                    .socket
+                    .send(&Packet::error(err.kind().into(), format!("{}", err)).into_bytes()[..]);
+                return Err(err);
+            }
 
             let ack = Packet::ack(data.body.block);
             let _ = self.socket.send(&ack.into_bytes()[..])?;
@@ -45,7 +50,16 @@ impl Connection {
         loop {
             let mut buf = [0; MAX_PAYLOAD_SIZE];
 
-            let bytes_read = reader.read(&mut buf)?;
+            let bytes_read = match reader.read(&mut buf) {
+                Ok(bytes_read) => bytes_read,
+                Err(err) => {
+                    let _ = self.socket.send(
+                        &Packet::error(err.kind().into(), format!("{}", err)).into_bytes()[..],
+                    );
+                    return Err(err);
+                }
+            };
+
             let data = Packet::data(Block::new(current_block), buf[..bytes_read].to_vec());
 
             let _ = self.socket.send(&data.into_bytes()[..])?;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -7,6 +7,8 @@ use crate::packet::*;
 /*
  * TODO: Probably add support for timeouts and retransmissions */
 
+pub const MIN_PORT_NUMBER: u16 = 1001;
+
 pub struct Connection {
     socket: UdpSocket,
 }

--- a/src/packet/expect.rs
+++ b/src/packet/expect.rs
@@ -1,0 +1,52 @@
+//! A utility trait for attempting to parse a desired Packet or producing
+//! an error.
+
+use std::io::Result;
+use std::net::UdpSocket;
+
+use super::Packet;
+use crate::bytes::{FromBytes, IntoBytes};
+use crate::packet::{error, Error};
+
+/// Implementors can attempt to produce a packet of a certain type from
+/// the provided bytes.
+///
+/// ## Remarks
+///
+/// Note that implementors may introduce side effects.
+pub trait ExpectPacket {
+    /// Tries to produce the desired packet type.
+    fn expect_packet<P: super::sealed::Packet, B: AsRef<[u8]>>(
+        &self,
+        bytes: B,
+    ) -> Result<Packet<P>>;
+}
+
+impl ExpectPacket for UdpSocket {
+    fn expect_packet<P: super::sealed::Packet, B: AsRef<[u8]>>(
+        &self,
+        bytes: B,
+    ) -> Result<Packet<P>> {
+        let bytes = bytes.as_ref();
+        match Packet::<P>::from_bytes(&bytes) {
+            // Yay
+            Ok(packet) => Ok(packet),
+            Err(_) => {
+                // If we didn't get the packet we were expecting, maybe the
+                // peer sent us an error packet.
+                if let Ok(err_pkt) = Packet::<Error>::from_bytes(&bytes) {
+                    Err(err_pkt.into())
+                } else {
+                    // Peer didn't send us the expected packet OR an error
+                    // packet. Send them our own error packet and terminate
+                    // the connection.
+                    let kind = error::Code::IllegalOperation;
+                    let err = Packet::error(kind, kind.as_str());
+                    let bytes = err.clone().into_bytes();
+                    let _ = self.send(&bytes[..]);
+                    Err(err.into())
+                }
+            }
+        }
+    }
+}

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -128,17 +128,21 @@ impl Packet<Error> {
     }
 }
 
-impl From<io::Error> for Packet<Error> {
-    fn from(err: io::Error) -> Packet<Error> {
-        let code = match err.kind() {
+impl From<ErrorKind> for Code {
+    fn from(kind: ErrorKind) -> Self {
+        match kind {
             ErrorKind::NotFound => Code::FileNotFound,
             ErrorKind::PermissionDenied => Code::AccessViolation,
             ErrorKind::AlreadyExists => Code::FileAlreadyExists,
             _ => Code::NotDefined,
-        };
+        }
+    }
+}
 
+impl From<io::Error> for Packet<Error> {
+    fn from(err: io::Error) -> Packet<Error> {
+        let code = err.kind().into();
         let message = format!("{}", code);
-
         Packet::error(code, message)
     }
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -15,6 +15,7 @@ pub use rq::{Rrq, Wrq};
 mod ack;
 mod data;
 mod error;
+pub mod expect;
 mod mode;
 mod opcode;
 mod rq;

--- a/src/server.rs
+++ b/src/server.rs
@@ -144,9 +144,8 @@ impl Handler {
         if let Direction::Put(wrq) = self.direction {
             let f = match OpenOptions::new()
                 .write(true)
-                .create(true)
+                .create_new(true)
                 /* FIXME: Not sure why this hangs if create is not specified */
-                .truncate(true)
                 .open(self.serve_dir.join(wrq.body.0.filename))
             {
                 Ok(f) => f,

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,6 +10,7 @@ use rand::Rng;
 
 use crate::bytes::{FromBytes, IntoBytes};
 use crate::connection::Connection;
+use crate::connection::MIN_PORT_NUMBER;
 use crate::packet::*;
 
 /// A TFTP server.
@@ -37,7 +38,7 @@ impl Server {
         serve_from: P,
     ) -> Result<(u16, Self)> {
         let mut rng = rand::thread_rng();
-        let port: u16 = rng.gen_range(1025, u16::MAX);
+        let port: u16 = rng.gen_range(MIN_PORT_NUMBER, u16::MAX);
         let bind_to = format!("{}:{}", ip_addr.as_ref(), port);
 
         Self::new(bind_to, serve_from).map(|server| (port, server))

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -1,10 +1,8 @@
-use std::thread;
+use std::{io, thread};
 
 use tftp::client;
 use tftp::packet::Mode;
 use tftp::Server;
-
-const REPO_ROOT: &str = env!("CARGO_MANIFEST_DIR");
 
 #[test]
 fn test_get() {
@@ -13,8 +11,7 @@ fn test_get() {
         "/artifacts/alice-in-wonderland.txt"
     ));
 
-    let mut serve_dir = REPO_ROOT.to_string();
-    serve_dir.push_str("/artifacts");
+    let serve_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/artifacts");
     let (port, server) = Server::random_port("127.0.0.1", serve_dir).unwrap();
     let server_addr = format!("127.0.0.1:{}", port);
 
@@ -36,4 +33,51 @@ fn test_get() {
     assert_eq!(&actual[..], &exemplar[..]);
 
     server_thread.join().unwrap();
+}
+
+#[derive(Debug)]
+struct ErroneousWriter;
+
+impl io::Write for ErroneousWriter {
+    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::Other, format!("Fake error")))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::Other, format!("Fake error")))
+    }
+}
+
+// NB: this test just hangs instead of failing before the fix is applied. we
+// could add a timeout here if we wanted it to fail instead.
+#[test]
+fn test_get_sends_error() {
+    // Create our server
+    let serve_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/artifacts");
+    let (port, server) = Server::random_port("127.0.0.1", serve_dir).unwrap();
+    let server_addr = format!("127.0.0.1:{}", port);
+
+    // Start a thread running its mainloop
+    let server_thread = thread::spawn(move || {
+        let handler = server.serve().unwrap();
+        handler.handle()
+    });
+
+    // Create our client
+    let client = client::Builder::new()
+        .unwrap()
+        .connect_to(server_addr)
+        .unwrap()
+        .build();
+
+    // When trying to write to a broken writer, the client should error out
+    let error = client
+        .get("alice-in-wonderland.txt", Mode::NetAscii, ErroneousWriter)
+        .unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+    assert_eq!(format!("{}", error.into_inner().unwrap()), "Fake error");
+
+    // When receiving an error packet (due to the broken writer), the server should error out as well
+    server_thread.join().unwrap().unwrap_err();
 }

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -74,7 +74,6 @@ fn test_get_sends_error() {
     let error = client
         .get("alice-in-wonderland.txt", Mode::NetAscii, ErroneousWriter)
         .unwrap_err();
-
     assert_eq!(error.kind(), io::ErrorKind::Other);
     assert_eq!(format!("{}", error.into_inner().unwrap()), "Fake error");
 


### PR DESCRIPTION
When I was writing the test for this new functionality, I noticed that the client, on a .put(), would be moved into that put() and thus couldn't be used anymore. Maybe we need another issue to fix this?﻿

Closes #24 