### PR TITLE
add server constructor that chooses a random port

### DIFF
--- a/tests/get.rs
+++ b/tests/get.rs
@@ -13,10 +13,11 @@ fn test_get() {
         "/artifacts/alice-in-wonderland.txt"
     ));
 
-    let server_addr = "127.0.0.1:6655";
     let mut serve_dir = REPO_ROOT.to_string();
     serve_dir.push_str("/artifacts");
-    let server = Server::new(server_addr, serve_dir).unwrap();
+    let (port, server) = Server::random_port("127.0.0.1", serve_dir).unwrap();
+    let server_addr = format!("127.0.0.1:{}", port);
+
     let server_thread = thread::spawn(move || {
         let handler = server.serve().unwrap();
         handler.handle().unwrap();

--- a/tests/put.rs
+++ b/tests/put.rs
@@ -6,10 +6,10 @@ use tftp::Server;
 
 #[test]
 fn test_put() {
-    let server_addr = "127.0.0.1:6655";
     let serve_dir = tempfile::tempdir().unwrap();
+    let (port, server) = Server::random_port("127.0.0.1", serve_dir.path()).unwrap();
+    let server_addr = format!("127.0.0.1:{}", port);
 
-    let server = Server::new(server_addr, serve_dir.path()).unwrap();
     let server_thread = thread::spawn(move || {
         let handler = server.serve().unwrap();
         handler.handle().unwrap();


### PR DESCRIPTION
closes #27

Do you want me to attempt to add this to (some of) the tests?
Please comment if the design fits your needs (e.g. if instead of an ip_addr arg you would prefer biding to localhost by default).