### PR TITLE
Add `try_clone` to `Builder<ConnectTo>`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -70,6 +70,16 @@ impl Builder<ConnectTo> {
             socket: self.data.socket,
         }
     }
+
+    /// Creates an instance with a different socket from the origninal instance.
+    pub fn try_clone(&self) -> Result<Self> {
+        let new_sock_builder = Builder::new()?;
+        let data = ConnectTo {
+            server: self.data.server.clone(),
+            socket: new_sock_builder.data.socket,
+        };
+        Ok(Builder { data })
+    }
 }
 
 impl Client {


### PR DESCRIPTION
Closes #33 

Since `Builder::<New>::new()` can fail, created a method `try_clone` which returns a `Result<Builder<ConnectTo>>`. This makes a new builder for the socket, and then uses the already constructed server from the current instance. 