### PR TITLE
Implement From to create Ack packet from Data packet

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -33,10 +33,11 @@ impl Connection {
                 return Err(err);
             }
 
-            let ack = Packet::ack(data.body.block);
+            let payload_size = data.body.data.len();
+            let ack = Packet::<Ack>::from(data);
             let _ = self.socket.send(&ack.into_bytes()[..])?;
 
-            if data.body.data.len() < MAX_PAYLOAD_SIZE {
+            if payload_size < MAX_PAYLOAD_SIZE {
                 break;
             }
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,7 +8,7 @@ use crate::packet::*;
 /*
  * TODO: Probably add support for timeouts and retransmissions */
 
-pub const MIN_PORT_NUMBER: u16 = 1001;
+pub const MIN_PORT_NUMBER: u16 = 1024;
 
 pub struct Connection {
     socket: UdpSocket,

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -128,6 +128,14 @@ impl Packet<Error> {
     }
 }
 
+impl From<Packet<Data>> for Packet<Ack> {
+    /// Create an `Ack` packet to acknowledge receipt of
+    /// a specific `Data` packet setting the correct `Block` number.
+    fn from(packet: Packet<Data>) -> Packet<Ack> {
+        Packet::ack(packet.body.block)
+    }
+}
+
 impl From<ErrorKind> for Code {
     fn from(kind: ErrorKind) -> Self {
         match kind {
@@ -281,5 +289,13 @@ mod tests {
         let expected = Packet::error(Code::FileNotFound, "file not found");
         let actual = Packet::<Error>::from_bytes(&bytes[..]).unwrap();
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_ack_from_data() {
+        let block_number = 129;
+        let data_packet = Packet::data(Block(block_number), vec![]);
+        let ack_packet = Packet::<Ack>::from(data_packet);
+        assert_eq!(ack_packet.body.block, Block(block_number));
     }
 }


### PR DESCRIPTION
Closes #22 

- implement `From<Packet<Data>>` for `Packet<Ack>`
- test that the block number is properly copied in above implementation

I'm not sure about the `use crate::packet::*`, whether you are happy with wildcard imports. I made this change so I could use both `Packet`s in the `ack.rs` file. Please let me know if you would instead prefer me to alias one of the `Packet`s.