### PR TITLE
[WIP] containerized end-to-end tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
 version: "3"
-version: "3"
 services:
     test:
         build:
             context: .
             dockerfile: ./dockerfiles/Dockerfile
         ports:
-            - "6655:6655"
-        expose: ["3000"]
+            - 6655:6655
         volumes:
-            - 
+            - ./artifacts:/usr/bin/artifacts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+version: "3"
+services:
+    test:
+        build:
+            context: .
+            dockerfile: ./dockerfiles/Dockerfile
+        ports:
+            - "6655:6655"
+        expose: ["3000"]
+        volumes:
+            - 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -53,9 +53,13 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     pkg-config \
     libssl-dev
 
-EXPOSE 6655
+#EXPOSE 6655
 
 COPY --from=build /build/target/debug/examples/server /usr/local/bin
+
+RUN mkdir /usr/local/bin/artifacts
+COPY --from=build /build/artifacts /usr/local/bin/artifacts
+
 WORKDIR /usr/local/bin
 
 CMD ["./server", "0.0.0.0:6655", "./artifacts"]

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -58,5 +58,4 @@ EXPOSE 6655
 COPY --from=build /build/target/debug/examples/server /usr/local/bin
 WORKDIR /usr/local/bin
 
-CMD ["echo", "hi"]
 CMD ["./server", "0.0.0.0:6655", "./artifacts"]

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,0 +1,62 @@
+# To produce a smaller image this Dockerfile contains two separate stages: in
+# the first one all the build dependencies are installed tftp is built,
+# while in the second one just the runtime dependencies are installed, with the
+# binary built in the previous stage copied there.
+
+#################
+#  Build stage  #
+#################
+
+FROM rust:1.43 as build
+
+# Build the dependencies in a separate step to avoid rebuilding all of them
+# every time the source code changes. This takes advantage of Docker's layer
+# caching, and it works by copying the Cargo.{toml,lock} with dummy source code
+# and doing a full build with it.
+RUN USER=root cargo new --bin tftp
+WORKDIR ./build
+COPY ./Cargo.toml ./Cargo.toml
+RUN mkdir examples && \
+    echo "fn main() {}" > examples/server.rs
+
+RUN cargo fetch
+RUN cargo build --example server
+
+# Dependencies are now cached, copy the actual source code and do another full
+# build. The touch on all the .rs files is needed, otherwise cargo assumes the
+# source code didn't change thanks to mtime weirdness.
+RUN rm -rf src server.rs
+
+COPY .git .git
+COPY examples examples/
+COPY src src/
+COPY artifacts artifacts/
+RUN find examples -name "*.rs" -exec touch {} \;
+RUN find src -name "*.rs" -exec touch {} \;
+RUN find artifacts -name "*.rs" -exec touch {} \;
+
+RUN cargo build --examples
+
+##################
+#  Output stage  #
+##################
+
+FROM debian:buster-slim AS output
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git \
+    libmagic1 \
+    docker.io \
+    ca-certificates \
+    build-essential \
+    gcc \
+    pkg-config \
+    libssl-dev
+
+EXPOSE 6655
+
+COPY --from=build /build/target/debug/examples/server /usr/local/bin
+WORKDIR /usr/local/bin
+
+CMD ["echo", "hi"]
+CMD ["./server", "0.0.0.0:6655", "./artifacts"]


### PR DESCRIPTION
This PR is for #3 

I've written a basic `Dockerfile` and `docker-compose` file to bring up the server. 

Run `docker-compose up -d --build` or `docker run -p 6655:6655 rust-debian` to bring the server up.

I am, however, having some problems with getting the client to make a `get` verb call. If I run `cargo run --example client 0.0.0.0:6655 get alice-in-wonderland.txt`, the client binary seems to just hang. I was wondering if anyone could help me figure this out?

I've tried to debug it but couldn't quite figure it out. Looking at the logs, `docker-compose logs` outputs the following: 
``` 
test_1  | Serving Trivial File Transfer Protocol (TFTP) @ 0.0.0.0:6655
```
I suspect that it is something to do with exposing/mapping the port. However, I believe I am mapping `6655:6655` in the `docker-compose` file. Would appreciate it if someone could check this out!