### PR TITLE
Resend last Ack in case it gets lost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -40,10 +40,10 @@ impl Connection {
             let ack = Packet::<Ack>::from(data);
 
             if payload_size < MAX_PAYLOAD_SIZE {
+                self.socket.set_read_timeout(Some(Duration::new(3, 0)))?;
                 loop {
                     let _ = self.socket.send(&ack.clone().into_bytes()[..])?;
 
-                    self.socket.set_read_timeout(Some(Duration::new(3, 0)))?;
                     if let Err(err) = self.socket.recv(&mut buf) {
                         match err.kind() {
                             io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut => {


### PR DESCRIPTION
Closes #56. Sets a timeout for "acking" the last package to three seconds. If the server sends the last packet again, the last Ack gets sent again. Due to platform specific behavior, the socket timeout expects either an `ErrorKind::WouldBlock` (Unix) or an `ErrorKind::TimedOut` (Windows) Error.